### PR TITLE
Issues #99 and #95 . Linkage error or class not found fixed.

### DIFF
--- a/bundles/com.eclipsesource.jshint.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.eclipsesource.jshint.ui/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.6.0",
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-ActivationPolicy: lazy
 Import-Package: com.eclipsesource.jshint;version="[0.9.10,1.0.0)",
- com.eclipsesource.json;version="0.9.0"
+ com.eclipsesource.json;version="[0.9.0.jshint,0.9.0.jshint]"
 Export-Package: com.eclipsesource.jshint.ui.internal;version="0.9.10";x-internal:=true,
  com.eclipsesource.jshint.ui.internal.builder;version="0.9.10";x-internal:=true,
  com.eclipsesource.jshint.ui.internal.preferences;version="0.9.10";x-internal:=true,

--- a/bundles/com.eclipsesource.jshint/META-INF/MANIFEST.MF
+++ b/bundles/com.eclipsesource.jshint/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Bundle-Vendor: EclipseSource
 Bundle-ActivationPolicy: lazy
 Export-Package: com.eclipsesource.jshint;version="0.9.10",
  com.eclipsesource.jshint.internal;version="0.9.10";x-friends:="com.eclipsesource.jshint.test",
- com.eclipsesource.json;version="0.9.0"
+ com.eclipsesource.json;version="0.9.0.jshint"
 Require-Bundle: org.mozilla.javascript;bundle-version="1.7.4"


### PR DESCRIPTION
This should fix the LinkageError or at least the ParseException I have reported in Issue #99. Basically, what I found is that jshint.ui was not using json implementation from jshint plugin, but possibly some other version (provided by Tern or NodeJS). Altough this commit should fix the issue for JSHint, installing JSHint it into Eclipse still may brake other plugins, since the shipped json package is modified. The full solution here would be to put modified version of json package into a different package (like e.g. com.eclipsesource.jshint.json). This would help avoid confusion.
